### PR TITLE
support generic attribute binding

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -44,7 +44,12 @@ o_O.bindElementToRule = function(el, attr, expr, context) {
       return $(el)[attr].call($(el), y)
     } 
     
-    return o_O.bindings[attr].call(context, y, $(el))
+    var binding = o_O.bindings[attr]·
+    if(binding != null && binding != 'undefined') {
+      return binding.call(context, y, $(el))
+    } else {
+      o_O.bindings.attr.call(context, {key: attr, value: y}, $(el))
+    }
   })
 }
 

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -20,7 +20,7 @@ o_O.bindings['class'] = function(klass, $el) {
    $el.attr('class', klass)
 }
 
-/* class
+/* generic attribute binding
  * usage: bind='href: myUrl()' 
  */
 

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -20,6 +20,14 @@ o_O.bindings['class'] = function(klass, $el) {
    $el.attr('class', klass)
 }
 
+/* class
+ * usage: bind='href: myUrl()' 
+ */
+
+o_O.bindings['attr'] = function(attr, $el) {
+   $el.attr(attr.key, attr.value)
+}
+
 /* Two-way binding to a form element
  * usage: bind='value: myProperty'
  * special cases for checkbox


### PR DESCRIPTION
support the following use case:

``` html
<a bind='text: myText(); href: myUrl()' />
```

currently it will fail when it tries to bind "href" because there is no specific binding configured for it in o_O.bindings
